### PR TITLE
Update runtime library to use pure functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ result
 *.cmi
 *.cmo
 .direnv
+*.beam


### PR DESCRIPTION
Update runtime library to use pure functions instead of having a separate process dedicated for environment actions.