### PR TITLE
Introduce dynamic scoping to control the Logger

### DIFF
--- a/README.org
+++ b/README.org
@@ -34,6 +34,8 @@ you are crazy enough to use it.
 
 * References
 
+- [[http://webyrd.net/scheme-2013/papers/HemannMuKanren2013.pdf][μKanren: A Minimal Functional Core for Relational Programming]]
+- [[https://okmij.org/ftp/ML/index.html#dynvar][Dynamic scoping implementation using OCaml Effect handlers]]
 - [[https://www.erlang.org/doc/apps/erts/absform.html][BEAM Abstract Form]]
 - [[https://webperso.info.ucl.ac.be/~pvr/VanRoyHaridi2003-book.pdf][Computer, Techniques, and Models of Computer Programming]]
 - [[https://users.dimi.uniud.it/~marco.comini/Students/Documentation/wam-book.pdf][Warren's Abtract Machine]]

--- a/bin/cmds/log.ml
+++ b/bin/cmds/log.ml
@@ -12,4 +12,4 @@ let term =
          unreachable. Levels lower than the chosen value are suppressed."
       ~docv:"LEVEL"
   in
-  Arg.value (Arg.opt conv Lib.Logger.Level.Debug info)
+  Arg.value (Arg.opt conv Lib.Logger.Level.default info)

--- a/bin/erl.ml
+++ b/bin/erl.ml
@@ -30,7 +30,7 @@ let compile prefix filepath forms =
   let forms =
     "[" ^ (String.concat "," @@ List.map Attribute.to_string forms) ^ "]"
   in
-  print_endline forms;
+  Logger.debug forms;
   let erlangProgram =
     "{ok, _, BeamByte} = compile:forms(" ^ forms ^ "), file:write_file(\""
     ^ prefix ^ "/" ^ name ^ ".beam\", BeamByte)"

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -24,7 +24,7 @@ let check_extensions (ext : BatSet.String.t) (files : string list) : unit =
 let run : cmd -> unit = function
   | Compile { files; artifact; output_path; log_level } ->
       (* TODO: Make sakura module name as an available CLI option with db being the default *)
-      Logger.Level.set_min_level log_level;
+      Logger.with_min_level log_level @@ fun () ->
       check_extensions (BatSet.String.of_list [ ".krt"; ".skr"; ".pl" ]) files;
       let open Shared.Compiler in
       let options : Options.t =

--- a/lib/Logger.ml
+++ b/lib/Logger.ml
@@ -1,10 +1,6 @@
 module Level = struct
   type t = Debug | Info | Warning | Error | Unreachable
   [@@deriving ord, enumerate, show]
-
-  let min_t : t ref = ref Debug
-  let set_min_level level = min_t := level
-  let should_log level = compare level !min_t >= 0
 end
 
 module type OUTPUT = sig
@@ -26,6 +22,14 @@ end
 
 module Make (Output : OUTPUT) = struct
   open Level
+
+  let current_min_level = External.Dynvar.dnew ~init:Debug ()
+
+  let with_min_level : 'a. Level.t -> (unit -> 'a) -> 'a =
+   fun level -> External.Dynvar.dlet current_min_level level
+
+  let should_log level =
+    Level.compare level (External.Dynvar.dref current_min_level) >= 0
 
   let unreachable_suffix =
     "This is a compiler bug. Please report it in \
@@ -176,11 +180,6 @@ module Terminal = Make (
   end :
     OUTPUT)
 
-type kind = Terminal | Server
-
-let current_kind = ref Terminal
-let set kind = current_kind := kind
-
 module type API = sig
   val error : Location.location -> string -> unit
   val simply_error : string -> unit
@@ -190,51 +189,52 @@ module type API = sig
   val simply_unreachable : string -> unit
   val info : Location.location -> string -> unit
   val simply_info : string -> unit
+  val with_min_level : 'a. Level.t -> (unit -> 'a) -> 'a
 
   (* TODO: Debug should receive location but location of THE SOURCE CODE OF THE COMPILER instead of Karuta source code. *)
   val debug : string -> unit
 end
 
-let kind2Module () =
-  match !current_kind with
-  | Terminal -> (module Terminal : API)
-  | Server ->
-      Terminal.simply_unreachable
-        "Server platform for logging is not implemented yet";
-      exit 1
+let current = External.Dynvar.dnew ~init:(module Terminal : API) ()
+let with_logger logger = External.Dynvar.dlet current logger
+let get_current_module () = External.Dynvar.dref current
 
 let simply_unreachable msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.simply_unreachable msg
 
 let unreachable loc msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.unreachable loc msg
 
 let simply_error msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.simply_error msg
 
 let error loc msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.error loc msg
 
 let simply_warning msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.simply_warning msg
 
 let warning loc msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.warning loc msg
 
 let simply_info msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.simply_info msg
 
 let info loc msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.info loc msg
 
 let debug msg =
-  let (module L) = kind2Module () in
+  let (module L) = get_current_module () in
   L.debug msg
+
+let with_min_level level =
+  let (module L) = get_current_module () in
+  L.with_min_level level

--- a/lib/Logger.ml
+++ b/lib/Logger.ml
@@ -1,6 +1,8 @@
 module Level = struct
   type t = Debug | Info | Warning | Error | Unreachable
   [@@deriving ord, enumerate, show]
+
+  let default = Info
 end
 
 module type OUTPUT = sig
@@ -23,13 +25,13 @@ end
 module Make (Output : OUTPUT) = struct
   open Level
 
-  let current_min_level = External.Dynvar.dnew ~init:Debug ()
+  let current_min_level = External.Dynvar.dnew ~init:Level.default ()
 
   let with_min_level : 'a. Level.t -> (unit -> 'a) -> 'a =
    fun level -> External.Dynvar.dlet current_min_level level
 
   let should_log level =
-    Level.compare level (External.Dynvar.dref current_min_level) >= 0
+    Level.compare (External.Dynvar.dref current_min_level) level <= 0
 
   let unreachable_suffix =
     "This is a compiler bug. Please report it in \

--- a/lib/external/dynvar.ml
+++ b/lib/external/dynvar.ml
@@ -1,0 +1,70 @@
+(** Dynamically scoped variables in Ocaml 5.x and beyond, using effects Dynamic
+    variables implemented here are safe with respect to exceptions *and*
+    effects.
+
+    If we implement a lightweight threading using OCaml effects, the dynamic
+    variables here work as expected. Naively implemented dynamic variables will
+    not: see ``Delimited Dynamic Binding'' with Chung-chieh Shan and Amr Sabry,
+    ICFP 2006.
+
+    Dynamic variables have a richer interface, as described in the above paper.
+*)
+
+open Effect
+
+let execute : 'a -> 'b = fun _ -> assert false
+
+type 'a dynvar = {
+  init : 'a option;
+  dref : unit -> 'a;
+  dset : 'a -> 'a;
+  dupp : 'w. ('a -> 'w) -> 'w;
+  catch : 'w. 'a -> (unit -> 'w) -> 'w;
+}
+
+let dnew : type a. ?init:a -> unit -> a dynvar =
+ fun ?init () ->
+  let open struct
+    type _ eff += Get : a eff | Set : a -> a eff | Up : 'w. (a -> 'w) -> 'w eff
+  end in
+  {
+    init;
+    dref =
+      (fun () ->
+        try perform Get with Unhandled _ when init <> None -> Option.get init);
+    dset = (fun x -> perform (Set x));
+    dupp = (fun g -> perform (Up g));
+    catch =
+      (fun x f ->
+        x
+        |>
+        try f () |> Fun.const with
+        | effect Get, k -> fun v -> (Deep.continue k (v : a)) v
+        | effect Set vnew, k -> fun v -> (Deep.continue k (v : a)) vnew
+        | effect Up g, k -> fun v -> (Deep.continue k (g v)) v);
+  }
+
+(* Dereferencing: obtain the value associated with the dynvar
+   by the closest dynamically-enclosing dlet *)
+let dref : 'a dynvar -> 'a = fun { dref } -> dref ()
+
+(* Given a dynvar, a value and a thunk, evaluate the thunk in the dynamic
+   environment extended with the binding of the given value to the
+   given dynvar
+*)
+let dlet : 'a dynvar -> 'a -> (unit -> 'w) -> 'w = fun { catch } -> catch
+
+(* Mutation: obtain the current value of the dynvar and change that
+   value to the given one. This `mutation' has the effect only
+   within the dynamic scope of the latest dlet
+   Return the previous value.
+*)
+let dset : 'a dynvar -> 'a -> 'a = fun { dset } -> dset
+
+(* Given a dynvar and a function, apply the function to the current
+   value of the dynvar, and return the result. The application
+   is evaluated in the dynamic environment _outside_ of the
+   closest dynamically-enclosing dlet. This lets us, for example,
+   access the previous binding to the dynamic variable.
+*)
+let dupp : 'a dynvar -> ('a -> 'w) -> 'w = fun { dupp } -> dupp

--- a/lib/external/dynvar.mli
+++ b/lib/external/dynvar.mli
@@ -1,0 +1,41 @@
+(** Dynamically scoped variables in Ocaml 5.x and beyond, using effects Dynamic
+    variables implemented here are safe with respect to exceptions *and*
+    effects.
+
+    If we implement a lightweight threading using OCaml effects, the dynamic
+    variables here work as expected. Naively implemented dynamic variables will
+    not: see ``Delimited Dynamic Binding'' with Chung-chieh Shan and Amr Sabry,
+    ICFP 2006.
+
+    Dynamic variables have a richer interface, as described in the above paper.
+*)
+
+(* The abstract type of dynamic variables *)
+type 'a dynvar
+
+(* Create a new dynvar, optionally setting the default value *)
+val dnew : ?init:'a -> unit -> 'a dynvar
+
+(* Given a dynvar, a value and a thunk, evaluate the thunk in the dynamic
+   environment extended with the binding of the given value to the
+   given dynvar
+*)
+val dlet : 'a dynvar -> 'a -> (unit -> 'w) -> 'w
+
+(* Dereferencing: obtain the value associated with the dynvar
+   by the closest dynamically-enclosing dlet *)
+val dref : 'a dynvar -> 'a
+
+(* Mutation: obtain the current value of the dynvar and change that
+   value to the given one. This `mutation' has the effect only
+   within the dynamic scope of the latest dlet
+*)
+val dset : 'a dynvar -> 'a -> 'a
+
+(* Given a dynvar and a function, apply the function to the current
+   value of the dynvar, and return the result. The application
+   is evaluated in the dynamic environment _outside_ of the
+   closest dynamically-enclosing dlet. This lets us, for example,
+   access the previous binding to the dynamic variable.
+*)
+val dupp : 'a dynvar -> ('a -> 'w) -> 'w

--- a/lib/karuta/Directive.ml
+++ b/lib/karuta/Directive.ml
@@ -14,7 +14,10 @@ let compile :
       let module Lookup = (val compiler.lookup) in
       let module_name' = (FT.empty, import_name) in
       let comptime_value = Lookup.ancestors_of_compiler compiler in
-      match Lookup.m0dule comptime_value module_name' with
+      match
+        Logger.with_min_level Logger.Level.Unreachable @@ fun () ->
+        Lookup.m0dule comptime_value module_name'
+      with
       | `Ok { loc; _ } | `UnexpectedSignature loc ->
           Logger.error import_name.loc "Import was already defined";
           Logger.error loc

--- a/lib/shared/Directive.ml
+++ b/lib/shared/Directive.ml
@@ -40,7 +40,10 @@ let rec compile : type state mods.
        } as module_) -> (
       let module_name' = (FT.empty, name) in
       let comptime_value = Lookup.ancestors_of_compiler compiler in
-      match Lookup.m0dule comptime_value module_name' with
+      match
+        Logger.with_min_level Logger.Level.Unreachable @@ fun () ->
+        Lookup.m0dule comptime_value module_name'
+      with
       | `Ok { loc; _ } | `UnexpectedSignature loc ->
           Logger.error module_loc "Failed to define module";
           Logger.error loc
@@ -80,7 +83,10 @@ let rec compile : type state mods.
       in
       let module_name' = (FT.empty, name) in
       let comptime_value = Lookup.ancestors_of_compiler compiler in
-      match Lookup.m0dule comptime_value module_name' with
+      match
+        Logger.with_min_level Logger.Level.Unreachable @@ fun () ->
+        Lookup.m0dule comptime_value module_name'
+      with
       | `Ok content ->
           {
             compiler with
@@ -109,6 +115,7 @@ let rec compile : type state mods.
       let module_name' = (FT.empty, name) in
       let comptime_value = Lookup.ancestors_of_compiler compiler in
       match
+        Logger.with_min_level Logger.Level.Unreachable @@ fun () ->
         ( Lookup.m0dule comptime_value module_name',
           Lookup.signature comptime_value signature_name )
       with


### PR DESCRIPTION
## Description

<!-- A clear and concise description of the changes in this PR. -->
We ditch normal mutable cells in favor of dynamically scoped variables to control the logging level.

## Related Issue

<!-- Link to the issue this PR addresses, if any. -->
<!-- Use "Closes #123" to auto-close the issue on merge. -->

Closes #27 

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Breaking change
- [X] Documentation update
- [X] Refactor / cleanup

## Checklist

- [ ] Tests added or updated
- [X] Documentation updated (if applicable)
- [ ] `nix fmt` run
