### PR TITLE
Fix CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,7 @@
                 (nix-filter.lib.inDirectory "bin")
                 (nix-filter.lib.inDirectory "lib")
                 (nix-filter.lib.inDirectory "test")
+                (nix-filter.lib.inDirectory "ppx_strip_payload")
                 (nix-filter.lib.inDirectory "examples")
               ];
             };


### PR DESCRIPTION
## Description

Our current flake is not taking into account the ppx library we are now using to remove payloads from ADTs.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if applicable)
- [ ] `nix fmt` run
