### PR TITLE
Remove path from show `ppx` for log levels

### DIFF
--- a/lib/Logger.ml
+++ b/lib/Logger.ml
@@ -1,6 +1,6 @@
 module Level = struct
   type t = Debug | Info | Warning | Error | Unreachable
-  [@@deriving ord, enumerate, show]
+  [@@deriving ord, enumerate, show { with_path = false }]
 
   let default = Info
 end


### PR DESCRIPTION
## Description

Removed the need to pass the modules' nesting (qualifiers) when using log levels in the CLI.

## Type of Change

- [X] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / cleanup

## Checklist

- [ ] Tests added or updated
- [ ] Documentation updated (if applicable)
- [ ] `nix fmt` run
